### PR TITLE
Add guest paywall scorecard and refine voice mode initialization

### DIFF
--- a/src/components/GamifiedRoleplay.tsx
+++ b/src/components/GamifiedRoleplay.tsx
@@ -15,6 +15,7 @@ import { useProspectVoice } from '@/hooks/useProspectVoice';
 import { isFacebookBrowser } from '@/utils/browserDetection';
 
 const WinCelebration = React.lazy(() => import('@/components/WinCelebration'));
+const ScorePaywall = React.lazy(() => import('@/components/ScorePaywall'));
 
 // ── Types ──────────────────────────────────────────────────────
 interface ObjectionCard {
@@ -1321,6 +1322,38 @@ const GamifiedRoleplay: React.FC<GamifiedRoleplayProps> = ({
           }}
         />
       </Suspense>
+    );
+  }
+
+  // ── Render: Guest paywall scorecard ─────────────────────────
+  // Guest (not logged in) users on /practice see the ScorePaywall instead of
+  // the full debrief, mirroring the cold-call-hook funnel. The cold call hook
+  // itself renders ScorePaywall from its own parent, so we skip this branch
+  // when isColdCallHook is set to avoid double-rendering.
+  if (phase === 'debrief' && debrief && isGuest && !isColdCallHook) {
+    const scorePercent = Math.round(debrief.score * 10);
+    const highlights: Array<{ text: string; passed: boolean }> = [];
+    if (debrief.strengths[0]) highlights.push({ text: debrief.strengths[0], passed: true });
+    if (debrief.gaps[0]) highlights.push({ text: debrief.gaps[0], passed: false });
+    if (debrief.gaps[1]) highlights.push({ text: debrief.gaps[1], passed: false });
+    if (highlights.length < 3 && debrief.strengths[1]) {
+      highlights.push({ text: debrief.strengths[1], passed: true });
+    }
+    return (
+      <div className="bg-gray-900 -mx-4 px-4 py-8 sm:py-10 rounded-2xl">
+        <Suspense
+          fallback={
+            <div className="flex items-center justify-center p-8 text-gray-400 text-sm">
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" /> Loading scorecard…
+            </div>
+          }
+        >
+          <ScorePaywall
+            score={scorePercent}
+            highlights={highlights.slice(0, 3)}
+          />
+        </Suspense>
+      </div>
     );
   }
 

--- a/src/components/GamifiedRoleplay.tsx
+++ b/src/components/GamifiedRoleplay.tsx
@@ -484,8 +484,11 @@ const GamifiedRoleplay: React.FC<GamifiedRoleplayProps> = ({
     setPhase('conversation');
     setIsAiTyping(true);
 
-    // Play phone ringing sound before first prospect message
-    await playCallStart();
+    // Play phone ringing sound before first prospect message — voice mode only.
+    // In text mode we skip the ringing and go straight to the first prospect message.
+    if (inputMode === 'voice') {
+      await playCallStart();
+    }
 
     try {
       const systemPrompt = presetScenario

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -47,7 +47,7 @@ const Index = () => {
   const [pendingUnlockSessionId, setPendingUnlockSessionId] = useState<string | null>(null);
   const coldCallUsed = typeof window !== 'undefined' && !!localStorage.getItem('pp_cold_call_used');
   const coldCallLocked = coldCallUsed && !user;
-  const coldCallLabel = coldCallLocked ? 'Get Started — More Rounds' : 'Try a Cold Call — Free';
+  const coldCallLabel = coldCallLocked ? 'Get Started Free' : 'Try a Cold Call — Free';
 
   // Check for an unfinished Stripe purchase whose buyer skipped the
   // /scorecard-unlock signup step. If they're still anonymous, surface


### PR DESCRIPTION
## Summary
This PR introduces a guest paywall scorecard for unauthenticated users and refines the voice mode initialization logic in the gamified roleplay component.

## Key Changes

- **Guest Paywall Scorecard**: Added `ScorePaywall` component rendering for guest users on the `/practice` route during the debrief phase. This mirrors the cold-call-hook funnel by showing a limited scorecard view instead of the full debrief, with highlights extracted from strengths and gaps.

- **Voice Mode Phone Ringing**: Modified the call initialization logic to only play the phone ringing sound in voice mode. Text mode now skips the ringing sound and goes directly to the first prospect message, improving the text-based user experience.

- **UI Label Update**: Simplified the cold call button label from "Get Started — More Rounds" to "Get Started Free" for locked users, providing clearer messaging.

## Implementation Details

- The `ScorePaywall` component is lazy-loaded with a suspense fallback to maintain performance
- Guest paywall rendering is conditional on `!isColdCallHook` to prevent double-rendering when the cold call hook manages its own paywall
- Score highlights are intelligently selected: first strength, up to two gaps, then second strength if needed, limited to 3 total items
- The voice mode check uses the existing `inputMode` prop to conditionally await `playCallStart()`

https://claude.ai/code/session_01CDXR3qG9TrTqJUVMM1piSC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance scorecard with key highlights for guest users during debrief

* **Improvements**
  * Call audio now plays only in voice mode; skipped in text conversations
  * Updated call-to-action button text based on feature access level

<!-- end of auto-generated comment: release notes by coderabbit.ai -->