### PR TITLE
fix(a11y): aria-labels, contrast tokens, heading-order skips

### DIFF
--- a/src/components/GamifiedRoleplay.tsx
+++ b/src/components/GamifiedRoleplay.tsx
@@ -1853,8 +1853,9 @@ const GamifiedRoleplay: React.FC<GamifiedRoleplayProps> = ({
             className={isListening ? 'border-destructive text-destructive animate-pulse' : isProcessingVoice ? 'border-yellow-500 text-yellow-500' : ''}
             disabled={isAiTyping || hungUp || isProcessingVoice}
             title={isProcessingVoice ? 'Processing voice...' : isListening ? 'Stop recording' : 'Tap to speak'}
+            aria-label={isProcessingVoice ? 'Processing voice…' : isListening ? 'Stop recording' : 'Start voice recording'}
           >
-            {isProcessingVoice ? <Loader2 className="w-5 h-5 animate-spin" /> : <Mic className="w-5 h-5" />}
+            {isProcessingVoice ? <Loader2 className="w-5 h-5 animate-spin" aria-hidden="true" /> : <Mic className="w-5 h-5" aria-hidden="true" />}
           </Button>
         )}
         <div className="flex-1 relative">

--- a/src/components/recordings/CallComparisonView.tsx
+++ b/src/components/recordings/CallComparisonView.tsx
@@ -84,8 +84,8 @@ const CallComparisonView: React.FC<CallComparisonViewProps> = ({ realCall, onBac
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
-        <Button variant="ghost" onClick={onBack} className="p-2">
-          <ArrowLeft className="h-5 w-5" />
+        <Button variant="ghost" onClick={onBack} className="p-2" aria-label="Back to call list">
+          <ArrowLeft className="h-5 w-5" aria-hidden="true" />
         </Button>
         <h2 className="text-xl font-semibold">Comparing Real Call vs Practice</h2>
       </div>
@@ -128,25 +128,26 @@ const CallComparisonView: React.FC<CallComparisonViewProps> = ({ realCall, onBac
                           className="my-1"
                         />
                         <div className="flex justify-center items-center gap-2 mt-4">
-                          <Button variant="outline" size="icon">
-                            <SkipBack className="h-4 w-4" />
+                          <Button variant="outline" size="icon" aria-label="Skip backward in real call">
+                            <SkipBack className="h-4 w-4" aria-hidden="true" />
                           </Button>
-                          <Button 
+                          <Button
                             onClick={togglePlay}
                             className="h-10 w-10 rounded-full bg-brand-blue"
+                            aria-label={isPlaying ? "Pause real call playback" : "Play real call playback"}
                           >
                             {isPlaying ? (
-                              <Pause className="h-5 w-5 text-white" />
+                              <Pause className="h-5 w-5 text-white" aria-hidden="true" />
                             ) : (
-                              <Play className="h-5 w-5 text-white" />
+                              <Play className="h-5 w-5 text-white" aria-hidden="true" />
                             )}
                           </Button>
-                          <Button variant="outline" size="icon">
-                            <SkipForward className="h-4 w-4" />
+                          <Button variant="outline" size="icon" aria-label="Skip forward in real call">
+                            <SkipForward className="h-4 w-4" aria-hidden="true" />
                           </Button>
                         </div>
                         <div className="flex items-center gap-2 mt-4">
-                          <Volume2 className="h-4 w-4" />
+                          <Volume2 className="h-4 w-4" aria-hidden="true" />
                           <Slider
                             value={[volume]}
                             min={0}
@@ -155,14 +156,14 @@ const CallComparisonView: React.FC<CallComparisonViewProps> = ({ realCall, onBac
                             onValueChange={handleVolumeChange}
                             className="w-24"
                           />
-                          <Button variant="outline" size="icon">
-                            <Download className="h-4 w-4" />
+                          <Button variant="outline" size="icon" aria-label="Download real call recording">
+                            <Download className="h-4 w-4" aria-hidden="true" />
                           </Button>
                         </div>
                       </div>
                     </div>
                   </TabsContent>
-                  
+
                   <TabsContent value="transcript">
                     <div className="bg-gray-50 rounded-md p-3 max-h-60 overflow-y-auto">
                       <p className="text-sm">
@@ -263,25 +264,26 @@ const CallComparisonView: React.FC<CallComparisonViewProps> = ({ realCall, onBac
                           className="my-1"
                         />
                         <div className="flex justify-center items-center gap-2 mt-4">
-                          <Button variant="outline" size="icon">
-                            <SkipBack className="h-4 w-4" />
+                          <Button variant="outline" size="icon" aria-label="Skip backward in practice session">
+                            <SkipBack className="h-4 w-4" aria-hidden="true" />
                           </Button>
-                          <Button 
+                          <Button
                             onClick={togglePlay}
                             className="h-10 w-10 rounded-full bg-brand-blue"
+                            aria-label={isPlaying ? "Pause practice session playback" : "Play practice session playback"}
                           >
                             {isPlaying ? (
-                              <Pause className="h-5 w-5 text-white" />
+                              <Pause className="h-5 w-5 text-white" aria-hidden="true" />
                             ) : (
-                              <Play className="h-5 w-5 text-white" />
+                              <Play className="h-5 w-5 text-white" aria-hidden="true" />
                             )}
                           </Button>
-                          <Button variant="outline" size="icon">
-                            <SkipForward className="h-4 w-4" />
+                          <Button variant="outline" size="icon" aria-label="Skip forward in practice session">
+                            <SkipForward className="h-4 w-4" aria-hidden="true" />
                           </Button>
                         </div>
                         <div className="flex items-center gap-2 mt-4">
-                          <Volume2 className="h-4 w-4" />
+                          <Volume2 className="h-4 w-4" aria-hidden="true" />
                           <Slider
                             value={[volume]}
                             min={0}
@@ -290,14 +292,14 @@ const CallComparisonView: React.FC<CallComparisonViewProps> = ({ realCall, onBac
                             onValueChange={handleVolumeChange}
                             className="w-24"
                           />
-                          <Button variant="outline" size="icon">
-                            <Download className="h-4 w-4" />
+                          <Button variant="outline" size="icon" aria-label="Download practice session recording">
+                            <Download className="h-4 w-4" aria-hidden="true" />
                           </Button>
                         </div>
                       </div>
                     </div>
                   </TabsContent>
-                  
+
                   <TabsContent value="transcript">
                     <div className="bg-gray-50 rounded-md p-3 max-h-60 overflow-y-auto">
                       <p className="text-sm">

--- a/src/components/recordings/RecentCalls.tsx
+++ b/src/components/recordings/RecentCalls.tsx
@@ -115,17 +115,17 @@ const RecentCalls: React.FC<RecentCallsProps> = ({ onSelectCall, selectedCall })
                   </div>
                   
                   <div className="flex gap-1">
-                    <Button size="icon" variant="ghost" onClick={(e) => {
+                    <Button size="icon" variant="ghost" aria-label={`Play recording: ${call.title}`} onClick={(e) => {
                       e.stopPropagation();
                       // Play audio logic would go here
                     }}>
-                      <Play className="h-4 w-4" />
+                      <Play className="h-4 w-4" aria-hidden="true" />
                     </Button>
-                    <Button size="icon" variant="ghost" onClick={(e) => {
+                    <Button size="icon" variant="ghost" aria-label={`Download recording: ${call.title}`} onClick={(e) => {
                       e.stopPropagation();
                       // Download audio logic would go here
                     }}>
-                      <Download className="h-4 w-4" />
+                      <Download className="h-4 w-4" aria-hidden="true" />
                     </Button>
                   </div>
                 </div>

--- a/src/components/voice/VoiceRecognitionManager.tsx
+++ b/src/components/voice/VoiceRecognitionManager.tsx
@@ -302,8 +302,9 @@ const VoiceRecognitionManager: React.FC<VoiceRecognitionManagerProps> = ({
           onClick={() => setShowDebugTools(!showDebugTools)}
           className="h-8 w-8"
           title="Debug Tools"
+          aria-label="Toggle microphone debug tools"
         >
-          <Bug size={14} />
+          <Bug size={14} aria-hidden="true" />
         </Button>
       </div>
       

--- a/src/index.css
+++ b/src/index.css
@@ -49,7 +49,9 @@ body {
     --secondary: 248 0.7% 96.8%;
     --secondary-foreground: 266 4% 20.8%;
     --muted: 248 0.7% 96.8%;
-    --muted-foreground: 257 4.6% 55.4%;
+    /* WCAG AA: darkened so text-muted-foreground hits 4.5:1 on white.
+       Was 257 4.6% 55.4% (#8B8892, 3.48:1). Now 5.33:1. */
+    --muted-foreground: 257 6% 44%;
     --accent: 248 0.7% 96.8%;
     --accent-foreground: 266 4% 20.8%;
     --destructive: 27 24.5% 57.7%;
@@ -189,6 +191,13 @@ body {
 @layer utilities {
   .text-balance {
     text-wrap: balance;
+  }
+
+  /* WCAG AA contrast override for the foreground text utility only.
+     Border/background/fill/stroke variants of gray-400 are NOT touched,
+     so input borders, icon strokes, and dividers keep their look. */
+  .text-gray-400 {
+    color: #6B7484; /* was #9CA3AF (2.54:1 on white) -> 4.71:1 on white */
   }
 }
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -445,7 +445,7 @@ const Index = () => {
                     <div className="pp-demo-score-inline">
                       <div className="pp-demo-score-num">7.4</div>
                       <div className="pp-demo-score-detail">
-                        <h4>Session Score</h4>
+                        <h3>Session Score</h3>
                         <p>Strong reframe on value. Good isolating question at the end. Work on: providing the proof faster. The prospect asked twice.</p>
                       </div>
                     </div>

--- a/src/pages/ScoreUnlock.tsx
+++ b/src/pages/ScoreUnlock.tsx
@@ -302,9 +302,9 @@ const ScoreUnlock: React.FC = () => {
             {/* Strengths */}
             {debrief.strengths.length > 0 && (
               <div className="mb-4">
-                <h3 className="text-xs uppercase tracking-widest text-emerald-400 mb-2">
+                <h2 className="text-xs uppercase tracking-widest text-emerald-400 mb-2">
                   What worked
-                </h3>
+                </h2>
                 <ul className="space-y-2 text-sm">
                   {debrief.strengths.map((s, i) => (
                     <li key={i} className="flex items-start gap-2 text-gray-200">
@@ -319,9 +319,9 @@ const ScoreUnlock: React.FC = () => {
             {/* Gaps */}
             {debrief.gaps.length > 0 && (
               <div className="mb-4">
-                <h3 className="text-xs uppercase tracking-widest text-red-400 mb-2">
+                <h2 className="text-xs uppercase tracking-widest text-red-400 mb-2">
                   What to fix
-                </h3>
+                </h2>
                 <ul className="space-y-2 text-sm">
                   {debrief.gaps.map((g, i) => (
                     <li key={i} className="flex items-start gap-2 text-gray-200">
@@ -336,9 +336,9 @@ const ScoreUnlock: React.FC = () => {
             {/* Coaching tip */}
             {debrief.tip && (
               <div className="bg-amber-500/10 border border-amber-500/30 border-l-4 border-l-amber-400 rounded-xl p-4">
-                <h3 className="text-xs uppercase tracking-widest text-amber-400 mb-1">
+                <h2 className="text-xs uppercase tracking-widest text-amber-400 mb-1">
                   Coach's tip
-                </h3>
+                </h2>
                 <p className="text-sm text-amber-100">{debrief.tip}</p>
               </div>
             )}


### PR DESCRIPTION
Three Lighthouse audit fixes against current main.

1. Icon-only buttons missing accessible names
   - CallComparisonView.tsx: back arrow, real-call SkipBack/SkipForward/Download + Play/Pause toggle, practice-call SkipBack/SkipForward/Download + Play/Pause
   - RecentCalls.tsx: per-row Play and Download
   - VoiceRecognitionManager.tsx: debug-tools toggle
   - GamifiedRoleplay.tsx: voice-mode mic toggle (was title-only)

2. WCAG AA contrast (target 4.5:1 for normal text on white)
   - --muted-foreground HSL 257 4.6% 55.4% (#8B8892, 3.48:1) -> 257 6% 44% (#6D6977, 5.33:1)
   - .text-gray-400 utility override (text color only, not borders/bg): #9CA3AF (2.54:1) -> #6B7484 (4.71:1) Also lifts the ComparisonTable "✗" cells out of failing contrast.

3. Heading order skips (semantic tag only, visual size preserved)
   - Index.tsx demo-card "Session Score": h4 -> h3 (parent section is h2)
   - ScoreUnlock.tsx "What worked" / "What to fix" / "Coach's tip": h3 -> h2 (parent page heading is h1, no h2 existed in between)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for voice recording controls, audio playback buttons, and action buttons with descriptive labels and proper icon annotations across recording and playback features.

* **Style**
  * Enhanced color contrast for improved readability and updated heading hierarchy in scorecard and demo sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->