### PR TITLE
perf: unblock font render to cut mobile homepage LCP

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,9 +47,16 @@
     <link rel="preconnect" href="https://ggpodadyycvmmxifqwlp.supabase.co" crossorigin />
     <link rel="dns-prefetch" href="https://ggpodadyycvmmxifqwlp.supabase.co" />
 
-    <!-- Critical font — preload + blocking link so @font-face with display=swap is available immediately -->
-    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <!-- Critical font — loaded asynchronously so it never blocks first paint / LCP.
+         The preload fetches the CSS at high priority, then onload flips it to a
+         stylesheet without blocking render. display=swap paints the hero text in a
+         system fallback immediately and swaps to Inter when it arrives. -->
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      onload="this.onload=null;this.rel='stylesheet'"
+    />
     <noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" /></noscript>
 
     <!-- Inline critical CSS for instant first paint -->

--- a/src/components/ColdCallHook.tsx
+++ b/src/components/ColdCallHook.tsx
@@ -323,7 +323,7 @@ const ColdCallHook: React.FC<ColdCallHookProps> = ({ open, onOpenChange }) => {
                 {isGoogleLoading ? (
                   <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                 ) : (
-                  <img src="https://www.google.com/favicon.ico" alt="" className="w-4 h-4 mr-2" />
+                  <img src="https://www.google.com/favicon.ico" alt="" width={16} height={16} loading="lazy" decoding="async" className="w-4 h-4 mr-2" />
                 )}
                 Continue with Google
               </Button>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -78,7 +78,10 @@ const About: React.FC = () => (
                 src={paulinaPhoto}
                 alt="Paulina Vol, Founder of PitchPerfect AI"
                 className="w-full h-full object-cover"
+                width={300}
+                height={400}
                 loading="lazy"
+                decoding="async"
               />
             </div>
 


### PR DESCRIPTION
The homepage hero is a text <h1> + CSS mockup card (no raster image), so the LCP element is the headline. It was being delayed on mobile because the Google Fonts stylesheet loaded as a render-blocking <link rel="stylesheet">, forcing a googleapis.com -> gstatic.com round-trip before first paint.

- index.html: load the Inter stylesheet asynchronously via rel=preload + onload swap (canonical non-blocking pattern). With the existing display=swap, the hero text paints immediately in a system fallback and swaps to Inter when ready — first paint/LCP no longer waits on the font network round-trip.
- About.tsx: add explicit width/height (300x400, matches the 3:4 frame) and decoding=async to the founder photo to reserve space and avoid CLS. Keeps loading=lazy (below the fold).
- ColdCallHook.tsx: add width/height + lazy/async to the Google favicon.

No hero image markup was added — there is no hero image on the homepage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized font loading strategy to load asynchronously without blocking initial page display
  * Enhanced image performance with updated attributes across components for improved rendering efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->