### PR TITLE
sec: rate-limit Stripe checkout session creation per IP

### DIFF
--- a/supabase/functions/create-payment/index.ts
+++ b/supabase/functions/create-payment/index.ts
@@ -1,6 +1,12 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@14.14.0?target=deno";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
+import { checkRateLimit, getClientIp, rateLimitResponse } from "../_shared/rateLimit.ts";
+
+// Anti-abuse: cap new Stripe checkout sessions per client IP to blunt
+// card-testing bots. To adjust, change these two constants.
+const MAX_CHECKOUTS_PER_WINDOW = 5;
+const RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -20,6 +26,13 @@ serve(async (req) => {
   }
 
   try {
+    // Server-side rate limit, enforced before any auth/DB/Stripe work so it
+    // can't be bypassed from the client. Keyed on client IP: 5 new checkout
+    // sessions per hour. Returns HTTP 429 with Retry-After when exceeded.
+    const ip = getClientIp(req);
+    const rl = checkRateLimit(`create-payment:ip:${ip}`, MAX_CHECKOUTS_PER_WINDOW, RATE_WINDOW_MS);
+    if (!rl.allowed) return rateLimitResponse(rl, corsHeaders);
+
     const stripeKey = Deno.env.get("STRIPE_SECRET_KEY");
     if (!stripeKey) throw new Error("Stripe secret key not configured");
 


### PR DESCRIPTION
Card-testing bots can hammer the create-payment edge function to spin up checkout sessions in bulk. Add a server-side per-IP rate limit using the existing _shared/rateLimit.ts helper: 5 new checkout sessions per IP per hour, returning HTTP 429 (with Retry-After) when exceeded.

Enforced at the very top of the request handler, before any auth, DB, or Stripe calls, so it cannot be bypassed from the client. Threshold is two named constants (MAX_CHECKOUTS_PER_WINDOW, RATE_WINDOW_MS) for easy tuning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added server-side limits on payment checkout attempts from a single IP address.
  * Requests that exceed the allowed rate now receive a clear “try again later” response, helping prevent abuse and improve payment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->