### PR TITLE
Fix cold-call scorecard rendering scores at 10x

### DIFF
--- a/src/components/ColdCallHook.tsx
+++ b/src/components/ColdCallHook.tsx
@@ -142,7 +142,7 @@ const ColdCallHook: React.FC<ColdCallHookProps> = ({ open, onOpenChange }) => {
   const handleComplete = useCallback((d: DebriefData) => {
     try {
       localStorage.setItem('pp_cold_call_used', 'true');
-      localStorage.setItem('pp_cold_call_last_score', String(Math.round(d.score * 10)));
+      localStorage.setItem('pp_cold_call_last_score', String(Math.round(d.score)));
       // Persist the full debrief so /scorecard-unlock can render the
       // unblurred scorecard after the user returns from Stripe checkout.
       localStorage.setItem('pp_cold_call_last_debrief', JSON.stringify(d));
@@ -256,7 +256,7 @@ const ColdCallHook: React.FC<ColdCallHookProps> = ({ open, onOpenChange }) => {
 
   const guestLocked = !user && typeof window !== 'undefined' && !!localStorage.getItem('pp_cold_call_used');
 
-  const scorePercent = debrief ? Math.round(debrief.score * 10) : 0;
+  const scorePercent = debrief ? Math.round(debrief.score) : 0;
 
   // Extract the top 2-3 feedback items from the AI scoring response for the
   // paywall's free "high-level bullets" row. Lead with one positive to feel good,


### PR DESCRIPTION
debrief.score is already normalized to 0-100 in GamifiedRoleplay's
runDebrief (both the API-scored and local-fallback paths clamp to that
range). ColdCallHook was multiplying by 10 again, so a real score of 25
rendered as "250/100" on the scorecard and was persisted the same way
to pp_cold_call_last_score.

Drop the * 10 from both the scorePercent memo and the localStorage
write.