### PR TITLE
Fix scorecard rendering scores at 10x across the app

### DIFF
--- a/src/components/ColdCallHook.tsx
+++ b/src/components/ColdCallHook.tsx
@@ -101,6 +101,19 @@ const ColdCallHook: React.FC<ColdCallHookProps> = ({ open, onOpenChange }) => {
     return () => vv.removeEventListener('resize', onResize);
   }, []);
 
+  // Pre-fix versions stored pp_cold_call_last_score pre-scaled by *10;
+  // rescale any legacy value. Idempotent — real 0-100 scores are left alone.
+  useEffect(() => {
+    try {
+      const v = localStorage.getItem('pp_cold_call_last_score');
+      if (!v) return;
+      const n = Number(v);
+      if (Number.isFinite(n) && n > 100) {
+        localStorage.setItem('pp_cold_call_last_score', String(Math.round(n / 10)));
+      }
+    } catch {}
+  }, []);
+
   // When the scorecard is visible, hide the page-level sticky mobile CTA
   // (.pp-mobile-cta at z-index: 100) so it doesn't cover the purchase
   // buttons inside the paywall. We toggle a body class so a single CSS

--- a/src/components/WinCelebration.tsx
+++ b/src/components/WinCelebration.tsx
@@ -13,7 +13,7 @@
  *  6. Buttons appear: "Run it back" + "Try different objection"
  *
  * Props:
- *  - score: number (1-10, from AI scoring)
+ *  - score: number (0-100, from AI scoring)
  *  - feedback: string (AI-generated summary of what worked)
  *  - bestLine: string (user's strongest quote from the session)
  *  - onRunItBack: () => void

--- a/src/pages/ScoreUnlock.tsx
+++ b/src/pages/ScoreUnlock.tsx
@@ -40,8 +40,8 @@ interface SavedDebrief {
   sessionStats?: { hungUp?: boolean };
 }
 
-const SCORE_HEX = (score10: number) =>
-  score10 < 5 ? '#ef4444' : score10 <= 7.5 ? '#eab308' : '#22c55e';
+const SCORE_HEX = (score: number) =>
+  score < 50 ? '#ef4444' : score <= 75 ? '#eab308' : '#22c55e';
 
 const ScoreUnlock: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -69,7 +69,7 @@ const ScoreUnlock: React.FC = () => {
     }
   }, []);
 
-  const scorePercent = debrief ? Math.round(debrief.score * 10) : null;
+  const scorePercent = debrief ? Math.round(debrief.score) : null;
 
   // Verify the Stripe session on mount
   useEffect(() => {

--- a/supabase/functions/send-feedback-email/index.ts
+++ b/supabase/functions/send-feedback-email/index.ts
@@ -104,7 +104,7 @@ const buildEmailHtml = (sessionData?: Record<string, unknown>) => {
       <div style="font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; color: #111827;">
         <h1 style="margin:0 0 12px; font-size:20px;">Your PitchPerfect AI Feedback</h1>
         <p style="margin:0 0 16px; color:#374151;">Thanks for practicing your pitch! Here's your instant recap.</p>
-        ${typeof score !== 'undefined' ? `<p style="margin:0 0 8px;"><strong>Score:</strong> ${Math.max(0, Math.min(10, Number(score) || 0))}/10</p>` : ''}
+        ${typeof score !== 'undefined' ? `<p style="margin:0 0 8px;"><strong>Score:</strong> ${Math.max(0, Math.min(100, Number(score) || 0))}/100</p>` : ''}
         ${escapedFeedback ? `<p style="margin:0 0 16px;"><strong>Overall Feedback:</strong> ${escapedFeedback}</p>` : ''}
         <h2 style="margin:16px 0 8px; font-size:16px;">What you did well</h2>
         ${strengthsHtml}


### PR DESCRIPTION
## Summary

`DebriefData.score` is normalized and clamped to 0-100 in `GamifiedRoleplay.runDebrief` (both the API-scored and local-fallback paths). Several downstream sites still multiplied by 10, so a real score of 25 rendered as "250/100" on the scorecard.

## Changes

- **`src/components/ColdCallHook.tsx`** — drop `* 10` on the score-percent memo and the `pp_cold_call_last_score` localStorage write. Add a one-time on-mount migration that rescales any legacy value > 100 already sitting in localStorage from the pre-fix version, so returning guests don't keep seeing "250%" on the locked signup heading.
- **`src/pages/ScoreUnlock.tsx`** — same `* 10` bug on the post-Stripe unlock page. Additionally `SCORE_HEX` used 0-10 thresholds (`<5`, `≤7.5`) while receiving a 0-100 value, so every score painted green; rewrite to `<50` / `≤75` to match `ScorePaywall`'s breakpoints.
- **`supabase/functions/send-feedback-email/index.ts`** — the email template clamped `score` to `Math.min(10, …)` and rendered `/10`. Every internal producer of a debrief score is 0-100, so a real 60% would email as "10/10". Widen the clamp to 100 and render `/100`.
- **`src/components/WinCelebration.tsx`** — docstring only. Claimed `score` was "1-10, from AI scoring" but the component has rendered `/100` for a while and its caller passes `debrief.score` (0-100). Update the doc to match.

## Test plan

- [ ] Complete a cold-call round as a guest and confirm the scorecard shows a plausible 0-100 score (not 10× inflated).
- [ ] With `pp_cold_call_last_score` set to a legacy value like `750` in localStorage, reload the cold-call hook and confirm the value gets rescaled to `75` on mount.
- [ ] Buy a scorecard unlock via Stripe and confirm `/scorecard-unlock` renders the real score, and the digit color matches the tier (red / amber / green).
- [ ] Trigger `send-feedback-email` with a `sessionData.score` of 60 and confirm the email shows "60/100".


---
_Generated by [Claude Code](https://claude.ai/code/session_01TS6CgDGzBKEQUr8dCkEBob)_