### PR TITLE
Add CI workflow: build + vitest on PRs and pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      # package-lock.json has 227 entries resolved against Lovable's private
+      # Artifact Registry, which the CI runner cannot reach. Rewrite them to
+      # the public registry before install; integrity hashes are per-tarball
+      # content, so they still match.
+      - run: sed -i 's|https://europe-west4-npm.pkg.dev/lovable-core-prod/sandbox-npm-cache|https://registry.npmjs.org|g' package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - run: npx vitest run


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml`. Runs `npm ci`, `npm run build`, and `npx vitest run` on every pull request and every push to `main`, on `ubuntu-latest` with Node 22.

The one non-obvious step is `sed`-rewriting `package-lock.json` before `npm ci`: 227 of its `resolved` URLs point at Lovable's private Artifact Registry (`europe-west4-npm.pkg.dev`), which a GitHub-hosted runner cannot reach. The sed replaces that prefix with `https://registry.npmjs.org`; integrity hashes in the lockfile are per-tarball content so they still match after the URL swap.

Follow-up to #67 — the toPercent PR merged without CI proving it, so this closes that gap going forward.

## Test plan

- [ ] Merging this PR triggers the workflow on `main` and it goes green (build + vitest both pass).
- [ ] Opening any subsequent PR (e.g. a trivial docs change) triggers the same workflow and it goes green.
- [ ] Introducing a deliberate broken import or a failing assertion in `src/lib/score.test.ts` on a branch makes the workflow red, so the gate actually gates.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TS6CgDGzBKEQUr8dCkEBob)_